### PR TITLE
Adds logic in customize trip view

### DIFF
--- a/app/assets/stylesheets/components/_cards.scss
+++ b/app/assets/stylesheets/components/_cards.scss
@@ -38,7 +38,7 @@
 .accommodation-card {
   width: 400px;
   height: 360px;
-  overflow: hidden;
+  // overflow: hidden;
   border-radius: 15px;
   box-shadow: 0 0 15px rgba(0,0,0,0.2);
   margin: 2% 3%;
@@ -47,6 +47,8 @@
   img {
     width: 100%;
     height: 160px;
+    border-top-right-radius: 15px;
+    border-top-left-radius: 15px;
     object-fit: cover;
   }
 }
@@ -102,11 +104,17 @@
 }
 
 .add-nights {
-  width: 350px;
-  height: 60px;
+  width: 250px;
+  height: 50px;
   border-radius: 100px;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.247);
-  font-size: 150%;
+  font-size: 130%;
+  background-color: white;
   position: absolute;
-  bottom: -50px;
+  bottom: -40px;
+  left: 70px;
 }
+
+.nights-text {
+    font-weight: bolder;
+  }

--- a/app/controllers/trip_stops_controller.rb
+++ b/app/controllers/trip_stops_controller.rb
@@ -1,8 +1,18 @@
 class TripStopsController < ApplicationController
+  # before_action :set_trip_stop_nights_counter
+
   def increase_nights
     @trip_stop = TripStop.find(params[:id])
     @trip_stop.increase_one_night!
-    @trip_stops.save
+    @trip_stop.save
+    redirect_to customize_path(@trip_stop.trip, anchor: "trip-stop-#{@trip_stop.id}")
+  end
+
+  def decrease_nights
+    @trip_stop = TripStop.find(params[:id])
+    @trip_stop.decrease_one_night!
+    @trip_stop.save
+    redirect_to customize_path(@trip_stop.trip, anchor: "trip-stop-#{@trip_stop.id}")
   end
 
   private

--- a/app/controllers/trip_stops_controller.rb
+++ b/app/controllers/trip_stops_controller.rb
@@ -5,7 +5,7 @@ class TripStopsController < ApplicationController
     @trip_stop = TripStop.find(params[:id])
     @trip_stop.increase_one_night!
     @trip_stop.save
-    @trip_stops.trip.update(end_date: start_date + trip.trip_stops.reduce(0) { |accumulator, trip_stop| accumulator + trip_stop.nights })
+    # @trip_stops.trip.update(end_date: start_date + trip.trip_stops.reduce(0) { |accumulator, trip_stop| accumulator + trip_stop.nights })
     redirect_to customize_path(@trip_stop.trip, anchor: "trip-stop-#{@trip_stop.id}")
   end
 
@@ -13,7 +13,7 @@ class TripStopsController < ApplicationController
     @trip_stop = TripStop.find(params[:id])
     @trip_stop.decrease_one_night!
     @trip_stop.save
-    @trip_stops.trip.update(end_date: start_date + trip.trip_stops.reduce(0) { |accumulator, trip_stop| accumulator + trip_stop.nights })
+    # @trip_stops.trip.update(end_date: start_date + trip.trip_stops.reduce(0) { |accumulator, trip_stop| accumulator + trip_stop.nights })
     redirect_to customize_path(@trip_stop.trip, anchor: "trip-stop-#{@trip_stop.id}")
   end
 

--- a/app/controllers/trips_controller.rb
+++ b/app/controllers/trips_controller.rb
@@ -1,13 +1,13 @@
 class TripsController < ApplicationController
 #  skip_before_action :authenticate_user!, only: [:new, :create, :edit, :update]
 
-  def new
-    @trip = Trip.new
-  end
+def new
+  @trip = Trip.new
+end
 
-  def create
-    @trip = Trip.new(trip_params)
-    @trip.user = current_user 
+def create
+  @trip = Trip.new(trip_params)
+  @trip.user = current_user 
     @trip.sent = false #eventualmente esto hay que ponerlo en el modelo y schema
     if @trip.save 
       redirect_to edit_trip_path(@trip)
@@ -35,27 +35,29 @@ class TripsController < ApplicationController
     @user = current_user
     @trips = Trip.where(user: current_user).where(sent: true)
   end
-    
+  
   def generate_trip_stops
-    #1 find trip
+    # 1 find trip
     trip = Trip.find(params[:id])
-    #aqui podria ir un if para evitar que se corra este metodo cuando ya se corrió
-    #2 generate trip stops and its activities
-      #a. find respective sample itinery
+    if trip.trip_stops.blank?
+    # 2 generate trip stops and its activities
+      # a. find respective sample itinery
       sample_itinerary = SampleItinerary.find(params[:sample_itinerary_id])
-      #b. find its stops and iterate over them
-      sample_itinerary.stops.each do |stop|    
-        #c. generating trip stops
+      trip.update(sample_itinerary: sample_itinerary)
+      # b. find its stops and iterate over them
+      sample_itinerary.stops.each do |stop|
+        # c. generating trip stops
         trip_stop = TripStop.new
         trip_stop.accommodation = stop.accommodation
         trip_stop.trip = trip
         trip_stop.nights = stop.nights
         trip_stop.save!
-        #d. for each trip stop add the corresponding activities(given the accommodation)
+        # d. for each trip stop add the corresponding activities(given the accommodation)
         stop.accommodation.activities.first(trip_stop.nights * 2).each do |activity|
           trip_stop_activity = TripStopActivity.create!(trip_stop: trip_stop, activity: activity)
         end
       end
+    end
     #3 save all
     redirect_to customize_path(trip)
   end

--- a/app/javascript/controllers/counter_controller.js
+++ b/app/javascript/controllers/counter_controller.js
@@ -1,0 +1,15 @@
+// import { Controller } from "stimulus";
+
+// export default class extends Controller {
+//   static targets = [ 'number' ];
+  
+//   connect() {
+//   }
+
+//   increase() {
+//     console.log(this.numberTarget)
+//     //conocer la cantidad de noches actual
+//     //aumentar esa cantidad en 1 por cada click
+//     //guardar en la base de datos
+//   }
+// }

--- a/app/javascript/controllers/hello_controller.js
+++ b/app/javascript/controllers/hello_controller.js
@@ -1,0 +1,18 @@
+// Visit The Stimulus Handbook for more details 
+// https://stimulusjs.org/handbook/introduction
+// 
+// This example controller works with specially annotated HTML like:
+//
+// <div data-controller="hello">
+//   <h1 data-target="hello.output"></h1>
+// </div>
+
+import { Controller } from "stimulus"
+
+export default class extends Controller {
+  static targets = [ "output" ]
+
+  connect() {
+    this.outputTarget.textContent = 'Hello, Stimulus!'
+  }
+}

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,0 +1,9 @@
+// Load all the controllers within this directory and all subdirectories. 
+// Controller files must be named *_controller.js.
+
+import { Application } from "stimulus"
+import { definitionsFromContext } from "stimulus/webpack-helpers"
+
+const application = Application.start()
+const context = require.context("controllers", true, /_controller\.js$/)
+application.load(definitionsFromContext(context))

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -31,3 +31,5 @@ document.addEventListener('turbolinks:load', () => {
   dateTripCounter();
   initFlatpickr();
 });
+
+import "controllers"

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -6,21 +6,4 @@ class Trip < ApplicationRecord
   has_many :travel_styles, through: :trip_styles
   accepts_nested_attributes_for :travel_styles
   validates :start_date, :end_date, :adults, presence: true
-
-  before_save :create_trip_stops
-
-  private
-
-  def create_trip_stops
-    return unless sample_itinerary_id_changed?
-
-    trip_stops.destroy_all
-
-    sample_itinerary.stops.each do |stop|
-      trip_stops.create(
-        accommodation: stop.accommodation,
-        nights: stop.nights
-      )
-    end
-  end
 end

--- a/app/models/trip_stop.rb
+++ b/app/models/trip_stop.rb
@@ -2,8 +2,13 @@ class TripStop < ApplicationRecord
   belongs_to :trip
   belongs_to :accommodation
   has_many :trip_stop_activities, dependent: :destroy
+  has_many :activities, through: :trip_stop_activities
 
   def increase_one_night!
-    nights += 1
+    self.nights += 1
+  end
+
+  def decrease_one_night!
+    self.nights -= 1 if nights.positive?
   end
 end

--- a/app/views/trips/customize.html.erb
+++ b/app/views/trips/customize.html.erb
@@ -1,101 +1,58 @@
-<div class="banner" style="background-image: linear-gradient(rgba(0,0,0,0),rgba(20,24,22,1) 92%), url(https://images.unsplash.com/photo-1612372992697-81c95501d0d1?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1650&q=80);">
+<div class="banner" style="background-image: linear-gradient(rgba(0,0,0,0),rgba(20,24,22,1) 92%), url(<%= cl_image_path @trip.sample_itinerary.photo.key %>);">
   <!-- agregar que la foto del banner sea la del sample_itinerary -->
   <div class="container">
-    <h1>Bush & Beach Getaway</h1>
-    <p>Recommended for Gonzalo</p>
-    <!-- que lo anterior sea customizado al sample y al usuario -->
+    <h1><%= @trip.sample_itinerary.title %> </h1>
+    <p><%= @trip.sample_itinerary.description %></p>
   </div>
 </div>
 
-<div class="container background-color: #f6f9fc">
-  <div class="container stop-card">
-    <span class="gray-header">Day 1: Arusha</span>
+<div class="container">
+  <% @trip.trip_stops.order(:id).each do |trip_stop| %>
+  <div class="container stop-card" id="trip-stop-<%= trip_stop.id %>">
+    <span class="gray-header"><%= trip_stop.accommodation.stops.first.place %></span>
     <div class="accommodation-card">
-      <img src="https://cf.bstatic.com/xdata/images/hotel/max1280x900/91711164.webp?k=c24e2f7f78b68c4336a2a29d7544d68ac369e6ffb4e6f3e775e09aaf7488afeb&o=" alt="rivertrees-country-inn">
+      <%= cl_image_tag trip_stop.accommodation.photo.key, height: 160, width: 400, gravity: :auto, crop: :fill %>
       <div class="row d-flex justify-content-between mx-3 my-1">
-        <h>Rivertrees Country Inn</h>
+        <h><%= trip_stop.accommodation.name %></h>
       </div>
       <div class="row d-flex justify-content-between mx-3">
-        <p>A charming country estate that was once an old coffee farm, on ten acres of fertile greenery, a sanctuary for the birds and wildlife indigenous to the area</p>
+        <p><%= trip_stop.accommodation.description %></p>
       </div>
-      <div class="add-nights mb-4 d-flex align-items-center justify-content-between">
-        <div class="ml-5"><strong>Adults</strong></div>
-        <div class="d-flex align-items-center mr-5">
-          <div class="mr-2"><div id="rest-adult-button" class="plus-and-less-button"><div class="text-black pb-1">-</div></div></div>
-          <div id="adult-number-place"></div>
-          <div class="ml-2"><div id="plus-adult-button" class="plus-and-less-button"><div class="text-black">+</div></div></div>
+      <div class="add-nights mb-4 d-flex align-items-center justify-content-center">
+        <div class="mx-4 nights-text">Nights</div>
+        <div class="d-flex align-items-center mr-4">
+          <%= link_to decrease_nights_path(trip_stop), method: :post, remote: true do %>
+            <div class="mr-2">
+              <div id="rest-adult-button" class="plus-and-less-button">
+                <div class="text-black pb-1">-</div>
+              </div>
+            </div>
+          <% end %>
+          <div>
+            <%= trip_stop.nights %>
+          </div>
+          <%= link_to increase_nights_path(trip_stop), method: :post, remote: true do %>
+            <div class="ml-2">
+              <div id="plus-adult-button" class="plus-and-less-button">
+                <span class="text-black">+</span>
+              </div>
+            </div>
+          <% end %>
         </div>
       </div>
     </div>
-
     <div class="activity-container">
       <h>Activities</h>
-      <div class="activity-card">
-        <img src="https://res.cloudinary.com/dafd6bi7v/image/upload/v1614888306/activities/Green_Footprint_Canoeing_htp0yv.jpg">
-          <div class="activity-card-infos">
-              <h2>Canoe Safari</h2>
-              <p>PYou will travel to Arusha National Park and canoe in a lake teeming with wildlife, including a family of hippos!</p>
-          </div>
+      <% trip_stop.accommodation.activities.each do |activity| %>
+        <div class="<%= 'bg-primary text-white' if trip_stop.activities.include?(activity) %>"><%= activity.name %>  
         </div>
-        <p class="btn btn-outline-primary" id="activity-btn">Change Activities</p>
-      </div>
+      <% end %>
     </div>
+  </div>
+  <% end %>
 
-    <div class="container stop-card">
-    <span class="gray-header">Day 2-5: Manyara National Park</span>
-    <div class="accommodation-card">
-      <img src="https://tourdust-production-images.s3.amazonaws.com/uploads/accommodation_image/image/2040/large_WAYOMAN2014-11.jpg">
-      <div class="row d-flex justify-content-between mx-3 my-1">
-        <h>Manyara Green Camp</h>
-        <h>$240 per night</h>
-      </div>
-      <div class="row d-flex justify-content-between mx-3">
-        <p>Deep in the forest, next to a waterfall and surrounded by wildlife. A stylish camp that is visited by elephants, buffaloes and many other animals who come to the river to drink.</p>
-      </div>
-    </div>
 
-    <div class="activity-container">
-      <h>Activities</h>
-      <div class="activity-card">
-        <img src="https://res.cloudinary.com/dafd6bi7v/image/upload/v1614888370/activities/P1011206_1_zvnk9c.jpg">
-          <div class="activity-card-infos">
-              <h2>Lakeside Walk</h2>
-              <p>Explore Manyara National Park on a half-day walk as you follow animal trails by the lakeside.</p>
-              <h2 class="mt-5">$100</h2>
-          </div>
-        </div>
-        <p class="btn btn-outline-primary" id="activity-btn">Change Activities</p>
-      </div>
-    </div>
-
-    <div class="container stop-card">
-    <span class="gray-header">Day 6-9: Serengeti National Park</span>
-    <div class="accommodation-card">
-      <img src="https://cdn.shortpixel.ai/client/q_lossy,ret_img,w_661,h_250/https://www.chaloafrica.com/wp-content/uploads/2018/04/Wayo-Kogatende-Green-Camp-Aerial-View-661x250.jpg">
-      <div class="row d-flex justify-content-between mx-3 my-1">
-        <h>Serengeti Green Camp</h>
-        <h>$240 per night</h>
-      </div>
-      <div class="row d-flex justify-content-between mx-3">
-        <p>Always in the heart of the Great Migration, this beautiful camp moves within the Serengeti to put you in prime locations for wildlife viewing.</p>
-      </div>
-    </div>
-
-    <div class="activity-container">
-      <h>Activities</h>
-      <div class="activity-card">
-        <img src="https://res.cloudinary.com/dafd6bi7v/image/upload/v1614891352/activities/Serengeti_Green_Camp_8_mtie4m.jpg">
-          <div class="activity-card-infos">
-              <h2>Serengeti Walk</h2>
-              <p>Enjoy a half-day walk through these epic plains looking for wildlife big and small. This activity is only available when the camp is in Northern Serengeti.</p>
-              <h2 class="mt-5">$100</h2>
-          </div>
-        </div>
-        <p class="btn btn-outline-primary" id="activity-btn">Change Activities</p>
-      </div>
-    </div>
-
-<div class="d-flex justify-content-center">
-  <div class="pb-5"><%= link_to  "Check Availability", confirmation_path, class:"btn btn-primary" %></div>
+  <div class="d-flex justify-content-center">
+    <div class="pb-5"><%= link_to  "Check Availability", confirmation_path, class:"btn btn-primary" %></div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,6 @@ Rails.application.routes.draw do
   get 'confirmation', to: "pages#confirmation"
   get 'trips/:id/generate', to: "trips#generate_trip_stops", as: :generate
   get 'trips/:id/customize', to: "trips#customize", as: :customize
+  post 'trip_stops/:id/increase_nights', to: "trip_stops#increase_nights", as: :increase_nights
+  post 'trip_stops/:id/decrease_nights', to: "trip_stops#decrease_nights", as: :decrease_nights
 end

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "flatpickr": "^4.6.9",
     "jquery": "^3.5.1",
     "popper.js": "^1.16.1",
+    "stimulus": "^2.0.0",
     "turbolinks": "^5.2.0"
   },
   "version": "0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -910,6 +910,30 @@
     webpack-cli "^3.3.12"
     webpack-sources "^1.4.3"
 
+"@stimulus/core@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@stimulus/core/-/core-2.0.0.tgz#140c85318d6a8a8210c0faf182223b8459348877"
+  integrity sha512-ff70GafKtzc8zQ1/cG+UvL06GcifPWovf2wBEdjLMh9xO2GOYURO3y2RYgzIGYUIBefQwyfX2CLfJdZFJrEPTw==
+  dependencies:
+    "@stimulus/mutation-observers" "^2.0.0"
+
+"@stimulus/multimap@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@stimulus/multimap/-/multimap-2.0.0.tgz#420cfa096ed6538df4a91dbd2b2842c1779952b2"
+  integrity sha512-pMBCewkZCFVB3e5mEMoyO9+9aKzHDITmf3OnPun51YWxlcPdHcwbjqm1ylK63fsoduIE+RowBpFwFqd3poEz4w==
+
+"@stimulus/mutation-observers@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@stimulus/mutation-observers/-/mutation-observers-2.0.0.tgz#3dbe37453bda47a6c795a90204ee8d77a799fb87"
+  integrity sha512-kx4VAJdPhIGBQKGIoUDC2tupEKorG3A+ckc2b1UiwInKTMAC1axOHU8ebcwhaJIxRqIrs8//4SJo9YAAOx6FEg==
+  dependencies:
+    "@stimulus/multimap" "^2.0.0"
+
+"@stimulus/webpack-helpers@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@stimulus/webpack-helpers/-/webpack-helpers-2.0.0.tgz#54296d2a2dffd4f962d2e802d99a3fdd84b8845f"
+  integrity sha512-D6tJWsAC024MwGEIKlUVYU8Ln87mlrmiwHvYAjipg+s8H4eLxUMQ3PZkWyPevfipH+oR3leuHsjYsK1gN5ViQA==
+
 "@types/glob@^7.1.1":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.3.tgz#e6ba80f36b7daad2c685acd9266382e68985c183"
@@ -6803,6 +6827,14 @@ stdout-stream@^1.4.0:
   integrity sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==
   dependencies:
     readable-stream "^2.0.1"
+
+stimulus@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/stimulus/-/stimulus-2.0.0.tgz#713c8b91a72ef90914b90955f0e705f004403047"
+  integrity sha512-xipy7BS5TVpg4fX6S8LhrYZp7cmHGjmk09WSAiVx1gF5S5g43IWsuetfUhIk8HfHUG+4MQ9nY0FQz4dRFLs/8w==
+  dependencies:
+    "@stimulus/core" "^2.0.0"
+    "@stimulus/webpack-helpers" "^2.0.0"
 
 stream-browserify@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
Populates the customize view with real data for each trip, including titles, descriptions and images.

![screencapture-localhost-3000-trips-19-customize-2021-03-09-20_41_43](https://user-images.githubusercontent.com/48967446/110553663-18c9ab00-8118-11eb-933b-51cde694ae97.png)

Allows increasing and decreasing of nights in each trip stop.
Lists activities of each stop, selecting the ones that are included in the trip stop.
Comments out price method that breaks code (we can fix it tommorrow)

